### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supports all ANSI colours and emphasis. Not compatible with Windows systems.
     )
     
     func main() {
-      fmt.Println(c.colourize("Hello World!", c.Green, c.Whitebg, c.Bold)
+      fmt.Println(c.Colourize("Hello World!", c.Green, c.Whitebg, c.Bold))
     }
 
 


### PR DESCRIPTION
If you run the code you provide you will get a compile error because lowercase 'colourize' is not  exported function , also you forgot to close the parenthsis.
Anyway nice job, continue this, make it working with  windows cmd too